### PR TITLE
feat(checks): no-root-gitignore default pre-tangle check (closes #15)

### DIFF
--- a/literate.lit.mdx/lib/checks.lit.mdx
+++ b/literate.lit.mdx/lib/checks.lit.mdx
@@ -20,7 +20,7 @@ rec {
 
 ## Pre-tangle checks
 
-Two checks run before Entangled writes output: `literate-structure` rejects code blocks that start with `//`/`/*`/`*/` (explanations belong in prose) and enforces minimum prose density; `input-title-tooltips` rejects `<input title=>` in favor of accessible info-button dialogs.
+Three checks run before Entangled writes output: `literate-structure` rejects code blocks that start with `//`/`/*`/`*/` (explanations belong in prose) and enforces minimum prose density; `input-title-tooltips` rejects `<input title=>` in favor of accessible info-button dialogs; `no-root-gitignore` rejects a project-root `.gitignore` because artifacts belong in the nix store, not in a tree-local ignore list — a `.gitignore` signals the literate discipline has been broken upstream. Consumers that need one (rare) can pass `allowRootGitignore = true`.
 
 ```{.nix file=lib/checks.nix as-a-real-non-nix-store-file="flake.nix imports this module"}
   mkDefaultPreTangleChecks = {
@@ -29,7 +29,8 @@ Two checks run before Entangled writes output: `literate-structure` rejects code
     tooltipCheckFile ? "literate/index.lit.md",
     minProseLines ? 3,
     maxBlockLength ? 50,
-    enforceDirectoryMatch ? false
+    enforceDirectoryMatch ? false,
+    allowRootGitignore ? false
   }:
     lib.flatten [
       [{
@@ -158,6 +159,31 @@ LITCHECK
           if grep -q '<input[^>]*title="' ${lib.escapeShellArg tooltipCheckFile} 2>/dev/null; then
             echo "[literate-state-machine-wiki] ERROR: <input> elements with title= tooltips found."
             grep -n '<input[^>]*title="' ${lib.escapeShellArg tooltipCheckFile} | head -10
+            exit 1
+          fi
+        '';
+      })
+      (lib.optional (!allowRootGitignore) {
+        name = "no-root-gitignore";
+        command = ''
+          offenders=""
+          [ -f .gitignore ] && offenders="$offenders .gitignore"
+          [ -f ${lib.escapeShellArg sourceDir}/.gitignore ] && offenders="$offenders ${sourceDir}/.gitignore"
+          if [ -n "$offenders" ]; then
+            echo "[literate-state-machine-wiki] ERROR: .gitignore found in project tree:$offenders"
+            echo ""
+            echo "  lsmw-consumer projects should not carry a .gitignore."
+            echo "  Artifacts belong in the nix store, not in an ignore list — a tracked"
+            echo "  .gitignore means the literate discipline has been broken upstream"
+            echo "  (node_modules/dist/result/etc. have leaked into the worktree)."
+            echo ""
+            echo "  Fixes:"
+            echo "    - build with 'nix build --no-link' so 'result' never lands"
+            echo "    - keep node_modules in the nix store (via bun2nix + initWeb)"
+            echo "    - for truly local-only excludes, use .git/info/exclude (uncommitted)"
+            echo ""
+            echo "  If you are sure you need one, pass 'allowRootGitignore = true' to"
+            echo "  lsmw.lib.init."
             exit 1
           fi
         '';
@@ -362,12 +388,13 @@ Each check in `preTangleChecks` / `postTangleChecks` gets its own named derivati
     minProseLines ? 3,
     maxBlockLength ? 50,
     enforceDirectoryMatch ? false,
+    allowRootGitignore ? false,
     stripGeneratedMarkers ? true,
     preTangleChecks ? [ ],
     postTangleChecks ? [ ]
   }:
     let
-      allPreChecks = (mkDefaultPreTangleChecks { inherit sourceDir forbidTsComments tooltipCheckFile minProseLines maxBlockLength enforceDirectoryMatch; }) ++ preTangleChecks;
+      allPreChecks = (mkDefaultPreTangleChecks { inherit sourceDir forbidTsComments tooltipCheckFile minProseLines maxBlockLength enforceDirectoryMatch allowRootGitignore; }) ++ preTangleChecks;
       allPostChecks = mkDefaultPostTangleChecks ++ postTangleChecks;
       tangled = pipeline.tangle { inherit src pkgs stripGeneratedMarkers; };
     in {
@@ -467,13 +494,14 @@ Five stages, four gates:
     minProseLines ? 3,
     maxBlockLength ? 50,
     enforceDirectoryMatch ? false,
+    allowRootGitignore ? false,
     stripGeneratedMarkers ? true,
     postTangle ? [],
     until ? null
   }:
     let
       allPreChecks = mkDefaultPreTangleChecks {
-        inherit sourceDir forbidTsComments tooltipCheckFile minProseLines maxBlockLength enforceDirectoryMatch;
+        inherit sourceDir forbidTsComments tooltipCheckFile minProseLines maxBlockLength enforceDirectoryMatch allowRootGitignore;
       };
 
       # Stage 1: Pre-check — validates literate structure

--- a/literate.lit.mdx/lib/init.lit.mdx
+++ b/literate.lit.mdx/lib/init.lit.mdx
@@ -40,11 +40,12 @@ rec {
     forbidTsComments ? true,
     minProseLines ? 3,
     maxBlockLength ? 50,
-    enforceDirectoryMatch ? false
+    enforceDirectoryMatch ? false,
+    allowRootGitignore ? false
   }:
     let
       verified = checksLib.makeVerify {
-        inherit pkgs src sourceDir forbidTsComments minProseLines maxBlockLength enforceDirectoryMatch;
+        inherit pkgs src sourceDir forbidTsComments minProseLines maxBlockLength enforceDirectoryMatch allowRootGitignore;
         inherit postTangle until;
       };
       cli = pkgs.writeShellScriptBin "literate-state-machine-wiki" ''


### PR DESCRIPTION
## What

New default pre-tangle check `no-root-gitignore` that fails if the consumer project has a `.gitignore` at its root or inside `sourceDir`.

Closes #15.

## Why

A tracked `.gitignore` in an lsmw consumer signals the literate discipline has been broken upstream — `node_modules`, `dist`, `result`, or `.direnv` have leaked into the worktree and the consumer is papering over it with an ignore list. The correct fix is always to stop the leak at its source (use `nix build --no-link`, keep node_modules in the nix store via `bun2nix`, or for truly local-only excludes use `.git/info/exclude` which is not committed). I hit this myself while scaffolding a new lsmw consumer (`voice-impression-slop-website`) — the project's owner flagged it as a hard invariant, and I would have caught it earlier if the library had enforced it.

## API

New optional param on `init`, `makeVerify`, `makeChecks`, `mkDefaultPreTangleChecks`:

- `allowRootGitignore ? false` — opt-out for the rare case. Default behaviour enables the check.

## Error message

When triggered, the consumer sees an actionable explanation:

\`\`\`
[literate-state-machine-wiki] ERROR: .gitignore found in project tree: .gitignore

  lsmw-consumer projects should not carry a .gitignore.
  Artifacts belong in the nix store, not in an ignore list — a tracked
  .gitignore means the literate discipline has been broken upstream
  (node_modules/dist/result/etc. have leaked into the worktree).

  Fixes:
    - build with 'nix build --no-link' so 'result' never lands
    - keep node_modules in the nix store (via bun2nix + initWeb)
    - for truly local-only excludes, use .git/info/exclude (uncommitted)

  If you are sure you need one, pass 'allowRootGitignore = true' to
  lsmw.lib.init.
\`\`\`

## Notes on CI

I ran \`nix build .#default\` on this branch and on a clean checkout of \`upstream/main\`. Both hit the same two pre-existing \`literate-structure\` violations (\`core/no-comments-in-blocks\` at \`init.lit.mdx:123-124\`, \`core/block-length\` in \`tests/unit.lit.mdx\` at 263 lines). Those are unrelated to this PR and present on main already. The no-root-gitignore check itself runs and passes on the lsmw repo (no root .gitignore exists here).

Standalone unit-checked the check logic: passes on a dir without .gitignore, fires with exit 1 on a dir that has one.