### PR TITLE
devshell hint + install-hooks with root allowlist

### DIFF
--- a/literate.lit.mdx/lib/devshell.lit.mdx
+++ b/literate.lit.mdx/lib/devshell.lit.mdx
@@ -54,10 +54,24 @@ The caller's `shellHook` appends after all three layers, so consumer-specific me
     in pkgs.mkShell {
       packages = [ (config.entangledFor pkgs) ] ++ basePackages ++ extraPackages;
       shellHook = ''
-        build() { nix build --no-link --print-out-paths "$@"; }
+        build() { command nix build --no-link --print-out-paths "$@"; }
         export -f build
+
+        # Soft nudge: warn when 'nix build' is used without --no-link, since
+        # ./result symlinks defeat the store-only invariant lsmw promises.
+        # A ban is too brittle; real prevention belongs at commit time via
+        # a pre-commit hook that rejects tracked tangled artifacts (see
+        # upstream issue #10). This is a friendly whitelist, not a wall.
+        nix() {
+          if [ "$1" = "build" ] && [[ " $* " != *" --no-link "* ]]; then
+            echo "[literate-state-machine-wiki] hint: 'build' (wraps --no-link) avoids creating ./result. Proceeding anyway." >&2
+          fi
+          command nix "$@"
+        }
+        export -f nix
         ${envExports}
         echo "[literate-state-machine-wiki] entangled: $(entangled --version 2>/dev/null || echo 'NOT FOUND')"
+        echo "[literate-state-machine-wiki] tangle & build: use 'build' (wraps --no-link --print-out-paths)."
         ${lib.optionalString (tangleCommand != null) ''
           if ${autoTangleCondition}; then
             echo "[literate-state-machine-wiki] Auto-tangling literate source..."

--- a/literate.lit.mdx/lib/init.lit.mdx
+++ b/literate.lit.mdx/lib/init.lit.mdx
@@ -99,14 +99,14 @@ builtin_allow=(
 user_allow=()
 if [ -f .lsmw-allow ]; then
   while IFS= read -r line; do
-    line="${line%%#*}"
-    line="${line## }"
-    line="${line%% }"
+    line="''${line%%#*}"
+    line="''${line## }"
+    line="''${line%% }"
     [ -z "$line" ] || user_allow+=("$line")
   done < .lsmw-allow
 fi
 
-allow_all=("${builtin_allow[@]}" "${user_allow[@]}" "$source_dir")
+allow_all=("''${builtin_allow[@]}" "''${user_allow[@]}" "$source_dir")
 
 staged="$(git diff --cached --name-only)"
 
@@ -119,7 +119,7 @@ while IFS= read -r path; do
   esac
   # Check built-in and user allow entries (exact match or glob).
   matched=0
-  for allowed in "${allow_all[@]}"; do
+  for allowed in "''${allow_all[@]}"; do
     case "$path" in
       "$allowed"|$allowed) matched=1; break ;;
     esac
@@ -133,7 +133,7 @@ if [ -n "$offenders" ]; then
   printf '%s' "$offenders" >&2
   echo "" >&2
   echo "only these paths may live at the consumer root:" >&2
-  for a in "${builtin_allow[@]}"; do echo "  $a" >&2; done
+  for a in "''${builtin_allow[@]}"; do echo "  $a" >&2; done
   echo "  $source_dir/ (literate wiki tree)" >&2
   echo "" >&2
   echo "if a file is literate source, move it into $source_dir/" >&2

--- a/literate.lit.mdx/lib/init.lit.mdx
+++ b/literate.lit.mdx/lib/init.lit.mdx
@@ -55,10 +55,102 @@ rec {
             nix build --no-link "''${2:-.}" "''${@:3}"
             echo "[literate-state-machine-wiki] Build complete."
             ;;
+          install-hooks)
+            # Install a git pre-commit hook that enforces the consumer-root
+            # allowlist: only a narrow set of paths (flake.nix, flake.lock,
+            # .gitignore, README, LICENSE, the sourceDir, optional extras
+            # from .lsmw-allow) may appear at the repository root. Everything
+            # else is rejected — language manifests, result symlinks, tangled
+            # .py files, pip venvs, node_modules, anything. This inverts the
+            # defaults: instead of blocklisting known bad files one at a time,
+            # the consumer must explicitly declare anything unusual.
+            if [ ! -d .git ]; then
+              echo "[literate-state-machine-wiki] error: not a git repo (no .git/ found)" >&2
+              exit 1
+            fi
+            mkdir -p .git/hooks
+            cat > .git/hooks/pre-commit <<'HOOK'
+#!/usr/bin/env bash
+# Auto-installed by literate-state-machine-wiki install-hooks.
+# Allowlist-based: only known-good paths at consumer root are permitted;
+# anything inside sourceDir is always permitted (it is the literate wiki).
+set -eu
+
+source_dir="''${LSMW_SOURCE_DIR:-literate.lit.mdx}"
+[ -d "$source_dir" ] || source_dir="literate"
+
+# Minimal built-in root allowlist. Consumers can add to this with a
+# `.lsmw-allow` file (one glob per line, comments with '#' ignored).
+builtin_allow=(
+  "flake.nix"
+  "flake.lock"
+  ".gitignore"
+  ".gitattributes"
+  ".envrc"
+  "README"
+  "README.md"
+  "LICENSE"
+  "LICENSE.md"
+  "AGENTS.md"
+  "CLAUDE.md"
+  ".lsmw-allow"
+)
+
+user_allow=()
+if [ -f .lsmw-allow ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line## }"
+    line="${line%% }"
+    [ -z "$line" ] || user_allow+=("$line")
+  done < .lsmw-allow
+fi
+
+allow_all=("${builtin_allow[@]}" "${user_allow[@]}" "$source_dir")
+
+staged="$(git diff --cached --name-only)"
+
+offenders=""
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  # Anything inside source_dir/ is always allowed (wiki tree).
+  case "$path" in
+    "$source_dir"/*) continue ;;
+  esac
+  # Check built-in and user allow entries (exact match or glob).
+  matched=0
+  for allowed in "${allow_all[@]}"; do
+    case "$path" in
+      "$allowed"|$allowed) matched=1; break ;;
+    esac
+  done
+  [ "$matched" = 1 ] || offenders="$offenders  $path"$'\n'
+done <<< "$staged"
+
+if [ -n "$offenders" ]; then
+  echo "[literate-state-machine-wiki] pre-commit: root-allowlist violation" >&2
+  echo "" >&2
+  printf '%s' "$offenders" >&2
+  echo "" >&2
+  echo "only these paths may live at the consumer root:" >&2
+  for a in "${builtin_allow[@]}"; do echo "  $a" >&2; done
+  echo "  $source_dir/ (literate wiki tree)" >&2
+  echo "" >&2
+  echo "if a file is literate source, move it into $source_dir/" >&2
+  echo "if a file is a derived artifact, do not commit it (it lives in the nix store)" >&2
+  echo "if a file is legitimately root-level, add its glob to .lsmw-allow" >&2
+  exit 1
+fi
+HOOK
+            chmod +x .git/hooks/pre-commit
+            echo "[literate-state-machine-wiki] installed .git/hooks/pre-commit (root-allowlist mode)"
+            ;;
           *)
             echo "literate-state-machine-wiki — opinionated literate build tool"
             echo ""
-            echo "Usage: literate-state-machine-wiki build [flake-ref]"
+            echo "Usage:"
+            echo "  literate-state-machine-wiki build [flake-ref]"
+            echo "  literate-state-machine-wiki install-hooks"
             exit 1
             ;;
         esac


### PR DESCRIPTION
Closes #10, #12, #18, #24 (partial — the missing piece for each).

## devshell (closes #12)

One-line hint on shell entry pointing consumers to the already-existing `build` wrapper (which already uses `--no-link`). Plus a soft warning when bare `nix build` runs without `--no-link`. Not a ban — per the 'all commands are whitelists' philosophy, enforcement belongs at commit time, not shell time.

## install-hooks (closes #10, #18, #24)

`literate-state-machine-wiki install-hooks` writes a `.git/hooks/pre-commit` that rejects commits at the consumer root matching anything outside this allowlist:

- `flake.nix`, `flake.lock`, `.envrc`
- `.gitignore`, `.gitattributes`
- `README`, `README.md`, `LICENSE`, `LICENSE.md`
- `AGENTS.md`, `CLAUDE.md`
- `$sourceDir/` (literate wiki tree)
- Anything the consumer explicitly lists in `.lsmw-allow` (globs, one per line)

Inverts defaults. Instead of blocklisting known anti-patterns one at a time (tangled .py, pyproject.toml, result symlink, .venv-*/, node_modules/, etc.), consumers must declare anything unusual. Matches gridinstruments' `bun.lock` + `bun.nix` pattern — lock files belong inside `sourceDir/`, manifests tangle from there via `tangleAndRead`.

## Field test

Used this on `voicebreaker-pipeline` (a Python consumer that had accumulated: `pyproject.toml`, `uv.lock`, stray `result/` symlinks, tangled `modules/*.py` duplicates, `.venv-demucs/`). The hook would have caught all of them.

## What this is not

- Not a ban on `nix build` (soft nudge only)
- Not a fix for the `tangleAndRead` gap (#10 also asks for round-trip verification — that's a separate follow-up)
- Not language-specific (allowlist works for any tangled output)